### PR TITLE
Resolving issue 62: Create a pre-push hook to pass detekt

### DIFF
--- a/documentation/detekt.md
+++ b/documentation/detekt.md
@@ -20,3 +20,58 @@ Sometimes you could suppress a warning and assume the risk to don't fix this war
 
 It's very common to include `detekt` task in the checking flow, or create a specific step in the CI tools to fail the PR if you have any warning in your code.
 In the case of `Los Androides` app, the `maxIssues` is configured to `0`, so the task fails if you don't have all the warnings fixed or suppressed. 
+
+# Using Detekt in pre-push stage
+
+It's very useful to have an automated script to run detekt task locally before pushing your code to the remote repository. This feature will avoid to 
+consume CI time running the detekt task during the pipeline, detecting the detekt warning before push the changes in the remote repository. 
+
+We can use the Git `pre-push` hook for this purpose. This feature was developed taking this guide as reference: 
+https://detekt.dev/docs/gettingstarted/git-pre-commit-hook/
+
+This is the script to run detekt:
+
+```shell
+#!/usr/bin/env bash
+echo "Running detekt check..."
+OUTPUT="/tmp/detekt-$(date +%s)"
+./gradlew detekt > $OUTPUT
+EXIT_CODE=$?
+if [ $EXIT_CODE -ne 0 ]; then
+  cat $OUTPUT
+  rm $OUTPUT
+  echo "***********************************************"
+  echo "                 Detekt failed                 "
+  echo " Please fix the above issues before committing "
+  echo "***********************************************"
+  exit $EXIT_CODE
+fi
+rm $OUTPUT
+```
+---
+### **Disclaimer:** 
+This script is only tested on MAC computer, so I'm not sure if you can have problems using it on any other OS. If you think we can do this compatible 
+with other OS, please create a PR to help the community.
+---
+
+# Manual way to create `pre-push` script
+
+You can do it manually by yourself creating a file called `pre-push` into the `projectRoot/.git/hooks/` folder containing the script above. This 
+script will be executed every time you are trying to push something into the remote repository. If the detekt task fails, the push is cancelled.
+
+**This pre-push hook needs to be executable, so you may need to change the permission (`chmod +x pre-push`).**
+
+# Gradle task to copy `pre-push` script
+
+You can use this Gradle task to easily copy the script from the repository to your local `.git/hooks/` path.
+
+* ### From commandline:
+```shell
+./gradlew copyDetektPrePushScript
+```
+
+* ### From gradle menu:
+
+You can find the `copyDetektPrePushScript` task in the `tools` group in your Gradle menu of the Android Studio.
+
+**This pre-push hook needs to be executable, so you may need to change the permission (`chmod +x pre-push`).**

--- a/gradle-scripts/detekt.gradle
+++ b/gradle-scripts/detekt.gradle
@@ -24,3 +24,20 @@ subprojects {
     }
 }
 
+task copyDetektPrePushScript() {
+    group = "tools"
+    doLast {
+        def origin = new File("${project.rootDir}/gradle-scripts/", "pre-push")
+        def targetPath = "${project.rootDir}/.git/hooks/"
+
+        if (!origin.exists()) {
+            throw new GradleException("We can't find the origin pre-push file")
+        } else {
+            copy {
+                from origin
+                into targetPath
+            }
+            println "Copying \"${origin.name}\" to the .git/hook/ folder"
+        }
+    }
+}

--- a/gradle-scripts/pre-push
+++ b/gradle-scripts/pre-push
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+echo "Running detekt check..."
+OUTPUT="/tmp/detekt-$(date +%s)"
+./gradlew detekt > $OUTPUT
+EXIT_CODE=$?
+if [ $EXIT_CODE -ne 0 ]; then
+  cat $OUTPUT
+  rm $OUTPUT
+  echo "***********************************************"
+  echo "                 Detekt failed                 "
+  echo " Please fix the above issues before committing "
+  echo "***********************************************"
+  exit $EXIT_CODE
+fi
+rm $OUTPUT


### PR DESCRIPTION
### :tophat: What is the goal?
Provide an easy way to implement a pre-push script to run detekt locally before pushing your code to remote any changes.

### :memo: Type of change
- [x] Documentation change

This closes #
- #62
