### PR TITLE
Use JUnit5 instead of 4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,11 @@ android {
     viewBinding {
         enabled true
     }
+    testOptions {
+        unitTests.all {
+            useJUnitPlatform()
+        }
+    }
 }
 
 dependencies {
@@ -91,7 +96,7 @@ dependencies {
 
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
 
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation "org.junit.jupiter:junit-jupiter:5.7.2"
     testImplementation "io.mockk:mockk:1.12.2"
     testImplementation "org.amshove.kluent:kluent-android:1.68"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"

--- a/app/src/test/java/com/losandroides/learn/domain/ItemRepositoryTest.kt
+++ b/app/src/test/java/com/losandroides/learn/domain/ItemRepositoryTest.kt
@@ -38,7 +38,7 @@ class ItemRepositoryTest {
     @Test
     @DisplayName("""
         GIVEN empty database
-        WHEN getITems
+        WHEN getItems
         THEN get items from remote
         AND save them locally
         AND return them

--- a/app/src/test/java/com/losandroides/learn/domain/ItemRepositoryTest.kt
+++ b/app/src/test/java/com/losandroides/learn/domain/ItemRepositoryTest.kt
@@ -13,10 +13,12 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
 @ExperimentalCoroutinesApi
+@DisplayName("ItemRepository Test")
 class ItemRepositoryTest {
 
     private val testDispatcher = StandardTestDispatcher()
@@ -25,7 +27,7 @@ class ItemRepositoryTest {
 
     private lateinit var subject: ItemRepository
 
-    @Before
+    @BeforeEach
     fun setUp() {
         subject = ItemRepository(
             localItemDatasource,
@@ -34,7 +36,14 @@ class ItemRepositoryTest {
     }
 
     @Test
-    fun `GIVEN empty database WHEN getItems THEN get items from remote, save them locally and return them`() {
+    @DisplayName("""
+        GIVEN empty database
+        WHEN getITems
+        THEN get items from remote
+        AND save them locally
+        AND return them
+    """)
+    fun test() {
         coEvery { localItemDatasource.isEmpty() } returns true
         coEvery { remoteItemDatasource.getItemsDTO() } returns buildItemsDTO().right()
 
@@ -50,7 +59,12 @@ class ItemRepositoryTest {
     }
 
     @Test
-    fun `GIVEN filled database WHEN getItems THEN return the local ones directly`() {
+    @DisplayName("""
+        GIVEN filled database
+        WHEN getItems
+        THEN return the local ones directly
+    """)
+    fun test2() {
         coEvery { localItemDatasource.isEmpty() } returns false
 
         runTest(testDispatcher) {

--- a/app/src/test/java/com/losandroides/learn/domain/ItemsUseCaseTest.kt
+++ b/app/src/test/java/com/losandroides/learn/domain/ItemsUseCaseTest.kt
@@ -5,10 +5,12 @@ import com.losandroides.learn.framework.relaxedMockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
 
 @ExperimentalCoroutinesApi
+@DisplayName("ItemsUseCase test")
 class ItemsUseCaseTest {
 
     private val testDispatcher = StandardTestDispatcher()
@@ -16,7 +18,7 @@ class ItemsUseCaseTest {
 
     private lateinit var useCase: ItemsUseCase
 
-    @Before
+    @BeforeEach
     fun setUp() {
         useCase = ItemsUseCase(
             itemRepository
@@ -24,7 +26,11 @@ class ItemsUseCaseTest {
     }
 
     @Test
-    fun `WHEN useCase is invoked THEN call repository`() {
+    @DisplayName("""
+        WHEN useCase is invoked
+        THEN call repository
+    """)
+    fun test() {
         runTest(testDispatcher) {
             useCase()
         }

--- a/app/src/test/java/com/losandroides/learn/presentation/MainViewModelTest.kt
+++ b/app/src/test/java/com/losandroides/learn/presentation/MainViewModelTest.kt
@@ -11,16 +11,23 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.DisplayName
 
 @ExperimentalCoroutinesApi
+@DisplayName("MainViewModel test")
 class MainViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
     private val itemsUseCase = mockk<ItemsUseCase>()
 
     @Test
-    fun `GIVEN some items WHEN MainViewModel is initialized THEN ItemsUseCase is called`() =
+    @DisplayName("""
+        GIVEN some items
+        WHEN MainViewModel is initialized
+        THEN ItemsUseCase is called
+    """)
+    fun test() =
         runTest(testDispatcher) {
             val items = buildItems()
             coEvery { itemsUseCase() } returns items.right()


### PR DESCRIPTION
### :tophat: What is the goal?
Here I'm changing JUnit4 to JUnit5, it's not only because of the long naming detekt complains but there is more interesting stuff that they will appear once the projects become bigger 😄 

Old 
<img width="713" alt="image" src="https://user-images.githubusercontent.com/15377724/168469283-a65deb41-ba55-4e7a-bbbb-6f38155ce76f.png">

New
<img width="740" alt="image" src="https://user-images.githubusercontent.com/15377724/168563183-6805bcfb-a3b4-4b4c-bf55-e16570c5f3f7.png">

### :memo: Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [√] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality not working as expected)
- [√] Refactoring
- [√] Documentation change
- [] Dependency upgrade

This closes #
